### PR TITLE
Removed logo from footer.

### DIFF
--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -49,11 +49,8 @@
 				</div>
 
 				<div class="pb-2 flex-grow-1 page-background" style="z-index:1;" />
-				<MudAppBar Elevation="1" Bottom="true" Fixed="false" Class="pb-3">
-					<MudLink Href="./" Style="position: absolute;"><MudImage Class="mt-4 mx-4" Src="images/WillSullDev_Logo.png" Alt="Logo" Height="48" /></MudLink>
-					<MudSpacer />
+				<MudAppBar Elevation="1" Bottom="true" Fixed="false" Class="pb-3" ToolBarClass="justify-center">
 					<SocialMedia />
-					<MudSpacer />
 				</MudAppBar>
 			</MudMainContent>
 		</div>


### PR DESCRIPTION
On very small screens, the scroll to top may overlap with the footer. But they would be incredibly small so close #49 for now.